### PR TITLE
Make 'get' the default but not only method

### DIFF
--- a/src/clj_ipfs_api/core.clj
+++ b/src/clj_ipfs_api/core.clj
@@ -18,9 +18,9 @@
                                          (join "/" cmd-vec))
         ipfs-params                 (dissoc params :request)]
     ; text for cat, json for everything else
-    (assoc (merge {:as (if (= (last cmd-vec) "cat") :text :json)}
+    (assoc (merge {:as (if (= (last cmd-vec) "cat") :text :json)
+                   :method :get}
                   (:request params)) 
-           :method :get
            :url full-url
            :query-params (if args (assoc ipfs-params :arg args) ipfs-params))))
 (defn- api-request


### PR DESCRIPTION
The previous implementation only allows 'get' requests, which excludes api calls such as ipfs/add, that use the request body to upload a file.

This PR makes 'get' the default method while allowing the user to override it if necessary.
