### PR TITLE
Update http-kit for better multipart support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [http-kit "2.1.18"]
+                 [http-kit "2.2.0"]
                  [cheshire "5.5.0"]])


### PR DESCRIPTION
Version 2.2.0 of http-kit client allows the content-type to be provided
for multipart parameters, allowing the direct adding of strings via ipfs/add
